### PR TITLE
docs: Removed SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The release toolkit is a series of small, composable tools that interact togethe
 
 The toolkit provides a series of commands, also available as GitHub Actions, that can compose with your existing pipelines to fully automate releases with meaningful, user-facing changelogs.
 
-change main
+change by tuanđv
 
 The way in which the toolkit works is the following:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The release toolkit is a series of small, composable tools that interact togethe
 
 The toolkit provides a series of commands, also available as GitHub Actions, that can compose with your existing pipelines to fully automate releases with meaningful, user-facing changelogs.
 
+change main
+
 The way in which the toolkit works is the following:
 
 1. Maintainers add human-readable changelog entries to the `## Unreleased` section in a [`CHANGELOG.md`](https://keepachangelog.com/en/1.0.0/) file.


### PR DESCRIPTION
This PR is to update the SECURITY.md file from the repository, as SECURITY.md files are centrally managed in the organization's [.github](https://github.com/newrelic/.github) repository. This allows for easy updates made by security in the future.